### PR TITLE
feat: `--no-frontend` support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {assertEmptyFolder} from './utils/cmd.utils';
 import {
   dfxNewProject,
   promptDfxCanisterType,
-  promptDfxInstall,
+  promptDfxInstall, promptDfxNoFrontend,
   promptDfxVersion
 } from './utils/dfx.utils';
 import {isWindows, osDisclaimer} from './utils/os.utils';
@@ -28,8 +28,9 @@ export const main = async () => {
   await assertEmptyFolder(project);
 
   const type: DfxCanisterType = await promptDfxCanisterType();
+  const noFrontend: boolean = await promptDfxNoFrontend();
 
-  await dfxNewProject({project, type});
+  await dfxNewProject({project, type, noFrontend});
 };
 
 (async () => {

--- a/src/utils/dfx.utils.ts
+++ b/src/utils/dfx.utils.ts
@@ -93,8 +93,25 @@ export const promptDfxCanisterType = async (): Promise<DfxCanisterType> => {
 
 export const dfxNewProject = async ({
   project,
-  type
+  type,
+  noFrontend
 }: {
   project: string;
   type: DfxCanisterType;
-}): Promise<number | null> => spawn({command: 'dfx', args: ['new', project, '--type', type]});
+  noFrontend: boolean;
+}): Promise<number | null> =>
+  spawn({
+    command: 'dfx',
+    args: ['new', project, '--type', type, ...(noFrontend ? ['--no-frontend'] : [])]
+  });
+
+export const promptDfxNoFrontend = async (): Promise<boolean> => {
+  const {value} = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message: 'Create a backend only project - i.e. no web application (frontend)?',
+    initial: false
+  });
+
+  return value;
+};


### PR DESCRIPTION
Resolves #3