### PR TITLE
feat: add internet identity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import {
 } from './utils/dfx.utils';
 import {isWindows, osDisclaimer} from './utils/os.utils';
 import {promptProject} from './utils/project.utils';
+import {addIIToProject, promptIIInstall} from './utils/internet-identity.utils';
+import {nextStepsDisclaimer} from './utils/info.utils';
 
 export const main = async () => {
   console.log(gray(`\ncreate-ic version ${version}`));
@@ -30,7 +32,18 @@ export const main = async () => {
   const type: DfxCanisterType = await promptDfxCanisterType();
   const noFrontend: boolean = await promptDfxNoFrontend();
 
+  const installII: boolean = noFrontend ? false : await promptIIInstall();
+
   await dfxNewProject({project, type, noFrontend});
+
+  if (!installII) {
+    nextStepsDisclaimer({installII, dir: project});
+    return;
+  }
+
+  await addIIToProject(project);
+
+  nextStepsDisclaimer({installII, dir: project});
 };
 
 (async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,17 @@ import {gray} from 'kleur';
 import {version} from '../package.json';
 import {assertEmptyFolder} from './utils/cmd.utils';
 import {
+  dfxDefaultNullArguments,
   dfxNewProject,
   promptDfxCanisterType,
-  promptDfxInstall, promptDfxNoFrontend,
+  promptDfxInstall,
+  promptDfxNoFrontend,
   promptDfxVersion
 } from './utils/dfx.utils';
+import {nextStepsDisclaimer} from './utils/info.utils';
+import {addIIToProject, promptIIInstall} from './utils/internet-identity.utils';
 import {isWindows, osDisclaimer} from './utils/os.utils';
 import {promptProject} from './utils/project.utils';
-import {addIIToProject, promptIIInstall} from './utils/internet-identity.utils';
-import {nextStepsDisclaimer} from './utils/info.utils';
 
 export const main = async () => {
   console.log(gray(`\ncreate-ic version ${version}`));
@@ -36,14 +38,16 @@ export const main = async () => {
 
   await dfxNewProject({project, type, noFrontend});
 
+  const dfxNullArguments = await dfxDefaultNullArguments();
+
   if (!installII) {
-    nextStepsDisclaimer({installII, dir: project});
+    nextStepsDisclaimer({installII, dir: project, dfxNullArguments});
     return;
   }
 
   await addIIToProject(project);
 
-  nextStepsDisclaimer({installII, dir: project});
+  nextStepsDisclaimer({installII, dir: project, dfxNullArguments});
 };
 
 (async () => {

--- a/src/types/dfx.d.ts
+++ b/src/types/dfx.d.ts
@@ -6,3 +6,11 @@ interface DfxManifest {
 }
 
 type DfxCanisterType = 'motoko' | 'rust';
+
+interface DfxJson {
+  canisters: Record<string, {
+    type: 'custom' | 'motoko' | 'assets' | 'rust',
+    candid?: string,
+    wasm?: string,
+  }>
+}

--- a/src/types/dfx.d.ts
+++ b/src/types/dfx.d.ts
@@ -8,9 +8,18 @@ interface DfxManifest {
 type DfxCanisterType = 'motoko' | 'rust';
 
 interface DfxJson {
-  canisters: Record<string, {
-    type: 'custom' | 'motoko' | 'assets' | 'rust',
-    candid?: string,
-    wasm?: string,
-  }>
+  canisters: Record<
+    string,
+    {
+      type: 'custom' | 'motoko' | 'assets' | 'rust';
+      candid?: string;
+      wasm?: string;
+      remote?: {
+        candid: string;
+        id: {
+          ic: string;
+        };
+      };
+    }
+  >;
 }

--- a/src/types/dfx.d.ts
+++ b/src/types/dfx.d.ts
@@ -14,6 +14,7 @@ interface DfxJson {
       type: 'custom' | 'motoko' | 'assets' | 'rust';
       candid?: string;
       wasm?: string;
+      build?: string;
       remote?: {
         candid: string;
         id: {

--- a/src/utils/dfx.utils.ts
+++ b/src/utils/dfx.utils.ts
@@ -45,6 +45,13 @@ const dfxVersion = async (): Promise<string> => {
   return version;
 };
 
+// v0.10.0 - https://github.com/dfinity/sdk/blob/master/CHANGELOG.adoc#feat-use-null-as-default-value-for-opt-arguments
+export const dfxDefaultNullArguments = async (): Promise<boolean> => {
+  const version = await dfxVersion();
+
+  return version.localeCompare('0.10.0', undefined, { numeric: true, sensitivity: 'base' }) > -1
+}
+
 const dfxUpgrade = async (): Promise<number | null> => spawn({command: 'dfx', args: ['upgrade']});
 
 export const promptDfxVersion = async () => {

--- a/src/utils/download.utils.ts
+++ b/src/utils/download.utils.ts
@@ -7,7 +7,7 @@ export const downloadDfxManifest = async (): Promise<DfxManifest> => {
   return JSON.parse(decoder.decode(buffer));
 };
 
-function downloadFromURL(url: string): Promise<Buffer> {
+export const downloadFromURL = (url: string): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
     get(url, async (res) => {
       if (res.statusCode !== undefined && [301, 302].includes(res.statusCode)) {

--- a/src/utils/info.utils.ts
+++ b/src/utils/info.utils.ts
@@ -1,8 +1,10 @@
 import {cyan} from 'kleur';
 
+// TODO if version < 0.10 ? --argument '(null)' : ''
+
 export const nextStepsDisclaimer = ({installII, dir}: {installII: boolean; dir: string}) =>
   console.log(`\nNext steps:
   1: cd ${cyan(dir)}
   2: ${cyan('dfx start --background --clean')}
-  3: ${cyan(`dfx deploy${installII ? " --no-wallet --argument '(null)'" : ''}`)}
+      3: ${cyan(`dfx deploy${installII ? " --no-wallet --argument '(null)'" : ''}`)}
 `);

--- a/src/utils/info.utils.ts
+++ b/src/utils/info.utils.ts
@@ -1,10 +1,18 @@
 import {cyan} from 'kleur';
 
-// TODO if version < 0.10 ? --argument '(null)' : ''
-
-export const nextStepsDisclaimer = ({installII, dir}: {installII: boolean; dir: string}) =>
+export const nextStepsDisclaimer = ({
+  installII,
+  dir,
+  dfxNullArguments
+}: {
+  installII: boolean;
+  dir: string;
+  dfxNullArguments: boolean;
+}) =>
   console.log(`\nNext steps:
   1: cd ${cyan(dir)}
   2: ${cyan('dfx start --background --clean')}
-      3: ${cyan(`dfx deploy${installII ? " --no-wallet --argument '(null)'" : ''}`)}
+  3: ${cyan(
+    `dfx deploy${installII ? ` --no-wallet${!dfxNullArguments ? " --argument '(null)'" : ''}` : ''}`
+  )}
 `);

--- a/src/utils/info.utils.ts
+++ b/src/utils/info.utils.ts
@@ -1,0 +1,8 @@
+import {cyan} from 'kleur';
+
+export const nextStepsDisclaimer = ({installII, dir}: {installII: boolean; dir: string}) =>
+  console.log(`\nNext steps:
+  1: cd ${cyan(dir)}
+  2: ${cyan('dfx start --background --clean')}
+  3: ${cyan(`dfx deploy${installII ? " --no-wallet --argument '(null)'" : ''}`)}
+`);

--- a/src/utils/internet-identity.utils.ts
+++ b/src/utils/internet-identity.utils.ts
@@ -1,0 +1,68 @@
+import {readFile, writeFile} from 'fs/promises';
+import {green} from 'kleur';
+import {downloadFromURL} from './download.utils';
+import {confirm} from './prompt.utils';
+
+export const promptIIInstall = async (): Promise<boolean> =>
+  confirm('Add a local copy of Internet Identity to the project?');
+
+const II_WASM_LOCAL_FILE = 'internet_identity.wasm';
+const II_CANDID_LOCAL_FILE = 'internet_identity.did';
+
+const downloadIIWasm = async (dir: string) => {
+  const buffer: Buffer = await downloadFromURL(
+    `https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm`
+  );
+
+  await writeFile(`${dir}/${II_WASM_LOCAL_FILE}`, buffer);
+};
+
+const downloadIICandid = async (dir: string) => {
+  const buffer: Buffer = await downloadFromURL(
+    `https://raw.githubusercontent.com/dfinity/internet-identity/main/src/internet_identity/internet_identity.did`
+  );
+
+  await writeFile(`${dir}/${II_CANDID_LOCAL_FILE}`, buffer, 'utf-8');
+};
+
+const updateDfxJson = async (dir: string) => {
+  const dfxJsonFilePath: string = `${dir}/dfx.json`;
+
+  const dfxJson: DfxJson = JSON.parse(await readFile(dfxJsonFilePath, 'utf-8'));
+
+  const {canisters}: DfxJson = dfxJson;
+
+  const dfxJsonWithII: DfxJson = {
+    ...dfxJson,
+    canisters: {
+      ...canisters,
+      internet_identity: {
+        type: 'custom',
+        candid: II_CANDID_LOCAL_FILE,
+        wasm: II_WASM_LOCAL_FILE
+      }
+    }
+  } as DfxJson;
+
+  await writeFile(dfxJsonFilePath, JSON.stringify(dfxJsonWithII, null, 2), 'utf-8');
+};
+
+const updateGitIgnore = async (dir: string) => {
+  const gitIgnoreFilePath: string = `${dir}/.gitignore`;
+
+  const gitIgnore: string = await readFile(gitIgnoreFilePath, 'utf-8');
+
+  const gitIgnoreII: string = `${gitIgnore}\n\n${II_WASM_LOCAL_FILE}\n${II_CANDID_LOCAL_FILE}`;
+
+  await writeFile(gitIgnoreFilePath, gitIgnoreII, 'utf-8');
+};
+
+export const addIIToProject = async (dir: string) => {
+  console.log('Adding Internet Identity...');
+
+  await Promise.all([downloadIIWasm(dir), downloadIICandid(dir)]);
+
+  await Promise.all([updateDfxJson(dir), updateGitIgnore(dir)]);
+
+  console.log(`II installed ${green('✔')}\n`);
+};

--- a/src/utils/internet-identity.utils.ts
+++ b/src/utils/internet-identity.utils.ts
@@ -39,7 +39,13 @@ const updateDfxJson = async (dir: string) => {
       internet_identity: {
         type: 'custom',
         candid: II_CANDID_LOCAL_FILE,
-        wasm: II_WASM_LOCAL_FILE
+        wasm: II_WASM_LOCAL_FILE,
+        remote: {
+          candid: II_CANDID_LOCAL_FILE,
+          id: {
+            ic: 'rdmx6-jaaaa-aaaaa-aaadq-cai'
+          }
+        }
       }
     }
   } as DfxJson;


### PR DESCRIPTION
# Motivation

Offer the option to add Internet Identity to the new project that is created.

# Note
The option is only suggested if the user choose to create a web app - i.e. do not select `--no-frontend`.

While developing this PR I noticed that `dfx` does not print out the "next steps", so I also added it within this PR as deployment with II requires specifying `--no-wallet --argument '(null)'`

# Screenshots

<img width="1179" alt="Capture d’écran 2022-06-17 à 17 15 10" src="https://user-images.githubusercontent.com/16886711/174327606-40166323-0332-44b3-b656-3ba63cb20d8d.png">

<img width="1179" alt="Capture d’écran 2022-06-17 à 17 15 19" src="https://user-images.githubusercontent.com/16886711/174327612-4288929c-af36-45e5-a212-fb0d4bd953ff.png">
